### PR TITLE
Generate JPA metamodel for JPA  notification models

### DIFF
--- a/email/model/jpa/pom.xml
+++ b/email/model/jpa/pom.xml
@@ -41,5 +41,11 @@
             <artifactId>blaze-notify-email-sns-sqs-feedback</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-jpamodelgen</artifactId>
+            <version>${version.hibernate}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/email/model/jpa/src/main/java/com/blazebit/notify/email/model/jpa/AbstractEmailNotification.java
+++ b/email/model/jpa/src/main/java/com/blazebit/notify/email/model/jpa/AbstractEmailNotification.java
@@ -23,6 +23,8 @@ import com.blazebit.notify.NotificationJobContext;
 import com.blazebit.notify.email.message.Attachment;
 import com.blazebit.notify.jpa.model.base.AbstractNotification;
 import com.blazebit.notify.template.api.TemplateProcessor;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +43,7 @@ import jakarta.validation.constraints.NotNull;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 public abstract class AbstractEmailNotification<ID> extends AbstractNotification<ID> implements ConfigurationSourceProvider {
 

--- a/email/model/jpa/src/main/java/com/blazebit/notify/email/model/jpa/AbstractFromEmail.java
+++ b/email/model/jpa/src/main/java/com/blazebit/notify/email/model/jpa/AbstractFromEmail.java
@@ -15,6 +15,8 @@
  */
 package com.blazebit.notify.email.model.jpa;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotNull;
@@ -25,6 +27,7 @@ import jakarta.validation.constraints.NotNull;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 public abstract class AbstractFromEmail extends BaseEntity<Long> {
 

--- a/jpa/model/base/pom.xml
+++ b/jpa/model/base/pom.xml
@@ -26,6 +26,12 @@
             <artifactId>blaze-job-jpa-model</artifactId>
             <version>${version.blaze-job}</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-jpamodelgen</artifactId>
+            <version>${version.hibernate}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test dependencies -->
 		<dependency>

--- a/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractJobInstanceBasedNotification.java
+++ b/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractJobInstanceBasedNotification.java
@@ -19,6 +19,8 @@ package com.blazebit.notify.jpa.model.base;
 import com.blazebit.notify.NotificationJobInstance;
 import com.blazebit.notify.NotificationRecipient;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -34,6 +36,7 @@ import jakarta.persistence.Table;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 @Table(name = "notification")
 public abstract class AbstractJobInstanceBasedNotification<ID extends AbstractNotificationId<?, ?>, R extends NotificationRecipient<?>, I extends NotificationJobInstance<?, ?>> extends AbstractNotification<ID> {

--- a/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotification.java
+++ b/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotification.java
@@ -22,6 +22,8 @@ import com.blazebit.job.jpa.model.JobConfiguration;
 import com.blazebit.job.jpa.model.TimeFrame;
 import com.blazebit.notify.Notification;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Lob;
 import jakarta.persistence.MappedSuperclass;
@@ -39,6 +41,7 @@ import java.util.Set;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 @Table(name = "notification")
 public abstract class AbstractNotification<ID> extends AbstractJobInstance<ID> implements Notification<ID>, com.blazebit.job.JobConfiguration {

--- a/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotificationJob.java
+++ b/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotificationJob.java
@@ -19,6 +19,8 @@ package com.blazebit.notify.jpa.model.base;
 import com.blazebit.job.jpa.model.AbstractJob;
 import com.blazebit.notify.NotificationJob;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.MappedSuperclass;
 
 /**
@@ -27,6 +29,7 @@ import jakarta.persistence.MappedSuperclass;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 public abstract class AbstractNotificationJob extends AbstractJob implements NotificationJob {
 

--- a/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotificationJobInstance.java
+++ b/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotificationJobInstance.java
@@ -20,6 +20,8 @@ import com.blazebit.job.JobInstanceProcessingContext;
 import com.blazebit.job.jpa.model.AbstractJobInstance;
 import com.blazebit.notify.NotificationJobInstance;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Transient;
 
@@ -30,6 +32,7 @@ import jakarta.persistence.Transient;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 public abstract class AbstractNotificationJobInstance<R> extends AbstractJobInstance<Long> implements NotificationJobInstance<Long, R> {
 

--- a/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotificationJobTrigger.java
+++ b/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotificationJobTrigger.java
@@ -21,6 +21,8 @@ import com.blazebit.job.Schedule;
 import com.blazebit.job.jpa.model.AbstractJobTrigger;
 import com.blazebit.notify.NotificationJobTrigger;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.MappedSuperclass;
 
 /**
@@ -30,6 +32,7 @@ import jakarta.persistence.MappedSuperclass;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 public abstract class AbstractNotificationJobTrigger<J extends AbstractNotificationJob> extends AbstractJobTrigger<J> implements NotificationJobTrigger {
 

--- a/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotificationRecipient.java
+++ b/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractNotificationRecipient.java
@@ -19,6 +19,8 @@ package com.blazebit.notify.jpa.model.base;
 import com.blazebit.job.jpa.model.BaseEntity;
 import com.blazebit.notify.NotificationRecipient;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import java.util.TimeZone;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
@@ -30,6 +32,7 @@ import java.util.Locale;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 public abstract class AbstractNotificationRecipient extends BaseEntity<Long> implements NotificationRecipient<Long> {
 

--- a/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractTriggerBasedNotificationJobInstance.java
+++ b/jpa/model/base/src/main/java/com/blazebit/notify/jpa/model/base/AbstractTriggerBasedNotificationJobInstance.java
@@ -20,6 +20,8 @@ import com.blazebit.job.JobInstanceProcessingContext;
 import com.blazebit.job.jpa.model.AbstractTriggerBasedJobInstance;
 import com.blazebit.notify.NotificationJobInstance;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Transient;
 
@@ -33,6 +35,7 @@ import jakarta.persistence.Transient;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @MappedSuperclass
 public abstract class AbstractTriggerBasedNotificationJobInstance<ID, R, J extends AbstractNotificationJob, T extends AbstractNotificationJobTrigger<J>> extends AbstractTriggerBasedJobInstance<ID, T> implements NotificationJobInstance<ID, R> {
 

--- a/jpa/model/expression/pom.xml
+++ b/jpa/model/expression/pom.xml
@@ -21,6 +21,12 @@
             <artifactId>blaze-notify-jpa-model-base</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-jpamodelgen</artifactId>
+            <version>${version.hibernate}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test dependencies -->
 		<dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -24,6 +24,7 @@
         <version.blaze-expression>1.0.0-Alpha33</version.blaze-expression>
         <version.blaze-domain>3.0.0-Alpha5</version.blaze-domain>
         <version.spring>6.2.1</version.spring>
+        <version.hibernate>6.6.4.Final</version.hibernate>
         <version.junit>4.12</version.junit>
         <version.surefire.plugin>3.5.2</version.surefire.plugin>
     </properties>
@@ -79,8 +80,6 @@
                 <configuration>
                     <source>${maven.compiler.argument.source}</source>
                     <target>${maven.compiler.argument.target}</target>
-                    <!-- Disable annotation processing via compiler plugin. -->
-                    <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
             </plugin>
             <plugin>

--- a/server/src/main/java/com/blazebit/notify/server/model/JobBasedEmailNotificationId.java
+++ b/server/src/main/java/com/blazebit/notify/server/model/JobBasedEmailNotificationId.java
@@ -18,6 +18,8 @@ package com.blazebit.notify.server.model;
 
 import com.blazebit.notify.jpa.model.base.AbstractNotificationId;
 
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
@@ -25,6 +27,7 @@ import jakarta.persistence.Embeddable;
  * @author Christian Beikov
  * @since 1.0.0
  */
+@Access(AccessType.PROPERTY)
 @Embeddable
 public class JobBasedEmailNotificationId extends AbstractNotificationId<Long, Long> {
 


### PR DESCRIPTION
This PR requires a new version of blaze-job that includes JPA metamodel so that the build succeeds.